### PR TITLE
Estä useamman sähköpostin käyttäminen samanaikaisesti

### DIFF
--- a/src/routes/top/+page.server.ts
+++ b/src/routes/top/+page.server.ts
@@ -10,7 +10,7 @@ export const actions: Actions = {
 	default: async ({ request, url }) => {
 		const data = await request.formData();
 		const email = data.get('email');
-		if (typeof email != 'string' || !email.endsWith('edu.turku.fi')) {
+		if (typeof email != 'string' || email.includes(",") || !email.endsWith('edu.turku.fi')) {
 			return {
 				success: false,
 				message: 'Syötä edu.turku.fi-sähköposti.'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"lib": [
+			"ES2016"
+		]
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
[Nodemailerin dokumentaation](https://nodemailer.com/message/) mukaan nodemailer tulkitsee pilkut to, cc ja bcc -kenttissä useamman eri sähköpostin erottajina. 

Käytännössä käyttäjät pystyvät siis lähettämään kirjautuessaan sähköpostia niin moneen osoitteeseen kuin haluavat, kunhan niistä viimeinen päättyy "edu.turku.fi".
Tämä pr korjaa tuon vian toistaiseksi, mutta tulevaisuudessa tämän kaltaiset tarkistukset voisi varmaan varmuuden vuoksi siirtää mail.ts -tiedostoon.

+oletetaan että käytössä on uudehko js versio, niin ts valittaa vähemmän